### PR TITLE
Make destination endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Snakemake Globus Demo
-=====================
+# Snakemake Globus Demo
 
 Example of using Globus with Snakemake via `globus-cli`.
 
@@ -14,3 +13,21 @@ The Snakefile script:
 * Downloads data from Globus to local filesystem
 * Does local processing
 * Uploads the results to Globus (for testing we are using the same endpoint, but it would be more meaningful with a third shared endpoint)
+
+## Configuration
+
+The most common use-case of Globus with ShowYourWork is probably to download a
+large dataset to your local cluster so you can do some processing on it.  If
+you want to share this workflow with other users, the remote endpoint will
+be the same for everyone, but the local endpoint will be the one on your
+cluster.  To support this, there is a `config.yaml` file where these options
+can be configured:
+```yaml
+DEST_ENDPOINT: 
+    UUID: c3dc2ae2-74c6-11e8-93bb-0a6d4e044368
+    remote_dir: /~/showyourwork/showyourwork_globus_demo/
+    local_dir: /mnt/home/lgarrison/showyourwork/showyourwork_globus_demo
+```
+The `UUID` should be set to your endpoint's UUID.  The `remote_dir` is the
+path to the download directory *as seen by the endpoint*; the `local_dir`
+should be the same directory as seen by Snakemake.

--- a/Snakefile
+++ b/Snakefile
@@ -1,11 +1,17 @@
-SOURCE_ENDPOINT = "ffc65d7a-0bf9-11ec-90b4-41052087bc27"
-DEST_ENDPOINT = "9d6d994a-6d04-11e5-ba46-22000b92c6ec"
+configfile: "config.yaml"
+
+from pathlib import Path
+
+SOURCE_ENDPOINT = config['endpoints']['SOURCE_ENDPOINT']['UUID']
 
 rule upload_results:
     input:
         "data/output_abacus.par"
-    shell:
-        "globus transfer {DEST_ENDPOINT}:/~/p/software/showyourwork_globus_demo/data/output_abacus.par {DEST_ENDPOINT}:/~/p/software/showyourwork_globus_demo/results/output_abacus.par"
+    run:
+        uuid = config['endpoints']['DEST_ENDPOINT']['UUID']
+        infn = Path(config['endpoints']['DEST_ENDPOINT']['remote_dir']) / 'data/output_abacus.par'
+        outfn = Path(config['endpoints']['DEST_ENDPOINT']['remote_dir']) / 'results/output_abacus.par'
+        shell("globus transfer {uuid}:{infn} {uuid}:{outfn}")
 
 rule process_data:
     input:
@@ -20,5 +26,10 @@ rule process_data:
 rule copy_data:
     output:
         "data/abacus.par"
-    shell:
-        "globus transfer {SOURCE_ENDPOINT}:/~/AbacusSummit_base_c000_ph000/abacus.par {DEST_ENDPOINT}:/~/p/software/showyourwork_globus_demo/data/abacus.par"
+    run:
+        import time
+        dst_uuid = config['endpoints']['DEST_ENDPOINT']['UUID']
+        dst_fn = Path(config['endpoints']['DEST_ENDPOINT']['remote_dir']) / "data/abacus.par"
+        shell("globus transfer {SOURCE_ENDPOINT}:/~/AbacusSummit_base_c000_ph000/abacus.par {dst_uuid}:{dst_fn}")
+        while not Path(output[0]).exists():
+            time.sleep(0.5)

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+endpoints:
+  SOURCE_ENDPOINT:
+    UUID: ffc65d7a-0bf9-11ec-90b4-41052087bc27
+  DEST_ENDPOINT: 
+    UUID: c3dc2ae2-74c6-11e8-93bb-0a6d4e044368
+    remote_dir: /~/showyourwork/showyourwork_globus_demo/
+    local_dir: /mnt/home/lgarrison/showyourwork/showyourwork_globus_demo


### PR DESCRIPTION
This expands the demo a bit to include a configuration file where the details of the destination endpoint can be configured.  The motivation for this is that in a ShowYourWork context, the source endpoint will probably be the same for all users, but the destination endpoint will be different for each user.

This also does a hacky `while ...: sleep(0.5)` to wait for the Globus transfer to complete.  The more robust thing would be to record the task ID and query it later.